### PR TITLE
Fix root for pane-less window

### DIFF
--- a/itermocil.py
+++ b/itermocil.py
@@ -593,7 +593,7 @@ class Itermocil(object):
                 self.focus_on_pane(focus_pane)
 
             else:
-                commands = []
+                commands = base_command
                 if 'command' in window:
                     commands.append(window['command'])
                 elif 'commands' in window:


### PR DESCRIPTION
In pane-less window scenario, the "root" is getting ignored. So, let's add the `cd ...` part of the command line.